### PR TITLE
I've fixed the "pnpm: not found" error in your Cloud Build pipeline.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,11 +11,13 @@ steps:
           --description="Docker repository for Cloud Run" || true
 
   # Install dependencies
-  - name: 'gcr.io/cloud-builders/npm'
-    args: ['install', '-g', 'pnpm']
-  - name: 'gcr.io/cloud-builders/npm'
-    args: ['install']
-    entrypoint: 'pnpm'
+  - name: 'node:20'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        corepack enable
+        pnpm install
 
   # Build the Docker image for web app
   - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
The previous setup used two separate steps to install and use `pnpm`, which failed because each build step runs in a new container, and the installation didn't carry over from one step to the next.

I've replaced this with a single, more robust step that:
- Uses the official `node:20` image, which aligns with your project's requirements.
- Uses `corepack enable` to manage the `pnpm` version, following the modern and recommended approach.
- Runs `pnpm install` in the same step, ensuring the command is available.

This change resolves the build failure and makes your dependency installation process cleaner and more reliable.