### PR TITLE
feat: enable BuildKit for cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,6 +21,8 @@ steps:
 
   # Build the Docker image for web app
   - name: 'gcr.io/cloud-builders/docker'
+    env:
+      - 'DOCKER_BUILDKIT=1'
     args: [
       'build',
       '-t',
@@ -29,7 +31,6 @@ steps:
       '-f',
       'apps/web/Dockerfile'
     ]
-
     id: 'Build-Web'
 
   # Push the Docker image for web app to Artifact Registry


### PR DESCRIPTION
The cloudbuild was failing because the web app's Dockerfile uses the `--mount=type=cache` flag, which requires BuildKit to be enabled.

This commit enables BuildKit for the web app's Docker build step in `cloudbuild.yaml` by setting the `DOCKER_BUILDKIT=1` environment variable. This will allow the build to use BuildKit features and should resolve the build failure.