### PR TITLE
fix(cloudbuild): remove incorrect entrypoint from tasks build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -21,6 +21,8 @@ steps:
 
   # Build the Docker image for web app
   - name: 'gcr.io/cloud-builders/docker'
+    env:
+      - 'DOCKER_BUILDKIT=1'
     args: [
       'build',
       '-t',
@@ -29,7 +31,6 @@ steps:
       '-f',
       'apps/web/Dockerfile'
     ]
-
     id: 'Build-Web'
 
   # Push the Docker image for web app to Artifact Registry
@@ -39,9 +40,6 @@ steps:
 
   # Build the Docker image for tasks app
   - name: 'gcr.io/cloud-builders/docker'
-
-    entrypoint: 'bash'
-
     args: [
       'build',
       '-t',


### PR DESCRIPTION
The 'Build-Tasks' step in the `cloudbuild.yaml` was failing with the error "bash: build: No such file or directory". This was because the step had an `entrypoint: 'bash'`, which caused the build arguments to be misinterpreted by the shell.

This commit removes the `entrypoint: 'bash'` from the 'Build-Tasks' step. This allows the `gcr.io/cloud-builders/docker` image to use its default `docker` entrypoint, which correctly interprets the build arguments.