### PR TITLE
fix(cloudbuild): enable BuildKit for tasks build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -40,6 +40,8 @@ steps:
 
   # Build the Docker image for tasks app
   - name: 'gcr.io/cloud-builders/docker'
+    env:
+      - 'DOCKER_BUILDKIT=1'
     args: [
       'build',
       '-t',


### PR DESCRIPTION
The `Build-Tasks` step was failing with a "BuildKit required" error. This was because the `apps/tasks/Dockerfile` was updated to use BuildKit features (like `--mount=type=cache`), but BuildKit was not enabled for this build step in `cloudbuild.yaml`.

This commit enables BuildKit for the `Build-Tasks` step by adding `env: ['DOCKER_BUILDKIT=1']`. This aligns it with the `Build-Web` step and ensures that the Docker build for the tasks service can leverage BuildKit features.