### PR TITLE
fix(cloudbuild): use sh as entrypoint for terraform step

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -59,7 +59,7 @@ steps:
 
   # Run Terraform
   - name: 'hashicorp/terraform:1.0.0'
-    entrypoint: 'bash'
+    entrypoint: 'sh'
     args:
       - '-c'
       - |


### PR DESCRIPTION
The `Terraform-Apply` step was failing with the error "bash: executable file not found". This is because the `hashicorp/terraform:1.0.0` image is a minimal image that does not include the `bash` shell.

This commit changes the entrypoint for the `Terraform-Apply` step from `bash` to `sh`. The `sh` shell is available in the terraform image and is sufficient for running the terraform commands in the script. This should resolve the build failure.