### PR TITLE
fix(cloudbuild): update terraform version and fix replication syntax

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -58,7 +58,7 @@ steps:
     id: 'Push-Tasks'
 
   # Run Terraform
-  - name: 'hashicorp/terraform:1.0.0'
+  - name: 'hashicorp/terraform:1.8.0'
     entrypoint: 'sh'
     args:
       - '-c'

--- a/terraform/modules/cloud-sql/main.tf
+++ b/terraform/modules/cloud-sql/main.tf
@@ -28,6 +28,10 @@ resource "random_password" "db_password" {
 
 resource "google_secret_manager_secret" "db_password_secret" {
   secret_id  = "db-password"
+
+  replication {
+    automatic = {}
+  }
 }
 
 resource "google_secret_manager_secret_version" "db_password_secret_version" {
@@ -37,6 +41,10 @@ resource "google_secret_manager_secret_version" "db_password_secret_version" {
 
 resource "google_secret_manager_secret" "db_user_secret" {
   secret_id  = "db-user"
+
+  replication {
+    automatic = {}
+  }
 }
 
 resource "google_secret_manager_secret_version" "db_user_secret_version" {


### PR DESCRIPTION
The Terraform apply step has been failing with a series of contradictory errors related to the `replication` block in `google_secret_manager_secret` resources. This indicates a likely incompatibility between the old Terraform CLI version (1.0.0) and the newer Google Provider versions being used.

This commit addresses this by:
1.  Updating the Terraform version in `cloudbuild.yaml` from `1.0.0` to `1.8.0`.
2.  Restoring the `replication` block in `modules/cloud-sql/main.tf` with the correct `automatic = {}` syntax, which is required by the provider.

These changes should resolve the version incompatibility and allow the Terraform configuration to be applied successfully.