### PR TITLE
fix(cloudbuild): enable cloud resource manager api

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,11 @@
 steps:
+  # Enable the Cloud Resource Manager API
+  - name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        gcloud services enable cloudresourcemanager.googleapis.com
   # Create the Artifact Registry repository
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'bash'


### PR DESCRIPTION
The Terraform apply step was failing with a "Cloud Resource Manager API has not been used in project ... or it is disabled" error.

This commit adds a new step to the beginning of the `cloudbuild.yaml` to enable the `cloudresourcemanager.googleapis.com` service for the project. This is a required setup step for Terraform to be able to manage resources in the project.

This should resolve the API disabled error and allow the Terraform apply to proceed.