### PR TITLE
fix(cloudbuild): update machine type to E2_HIGHCPU_8

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -119,4 +119,4 @@ images:
 
 options:
   logging: CLOUD_LOGGING_ONLY
-  machineType: E2_HIGHCPU_2
+  machineType: E2_HIGHCPU_8


### PR DESCRIPTION
The build was failing with an "unknown value" error for the `machineType` option. After investigation, it seems that `E2_HIGHCPU_2` is not a supported machine type in the default Cloud Build pool.

This commit updates the `machineType` to `E2_HIGHCPU_8`, which is explicitly mentioned in the Cloud Build documentation as a supported value. This should resolve the parsing error and also provide a significant performance boost to the build.