### PR TITLE
fix(cloudbuild): resolve final terraform apply errors

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
     args:
       - '-c'
       - |
-        gcloud services enable cloudresourcemanager.googleapis.com
+        gcloud services enable cloudresourcemanager.googleapis.com secretmanager.googleapis.com servicenetworking.googleapis.com
   # Create the Artifact Registry repository
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'bash'
@@ -78,6 +78,13 @@ steps:
       - '-c'
       - |
         gcloud storage buckets add-iam-policy-binding gs://${_TERRAFORM_STATE_BUCKET} --member=serviceAccount:1062316443287-compute@developer.gserviceaccount.com --role=roles/storage.objectAdmin || true
+  # Grant Compute Network Admin role to the Cloud Build service account
+  - name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        gcloud projects add-iam-policy-binding ${PROJECT_ID} --member=serviceAccount:1062316443287-compute@developer.gserviceaccount.com --role=roles/compute.networkAdmin || true
   # Run Terraform
   - name: 'hashicorp/terraform:1.12.2'
     entrypoint: 'sh'

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -41,6 +41,7 @@ module "cloud_sql" {
   region     = var.region
   network_id = module.vpc.network_id
   db_user = "db_user"
+  private_service_access_id = module.vpc.private_service_access_id
 }
 
 module "cloud_run" {

--- a/terraform/modules/cloud-sql/main.tf
+++ b/terraform/modules/cloud-sql/main.tf
@@ -1,4 +1,7 @@
 resource "google_sql_database_instance" "main" {
+  depends_on = [
+    var.private_service_access_id
+  ]
   project             = var.project_id
   name                = "private-db-instance"
   database_version    = "POSTGRES_13"

--- a/terraform/modules/cloud-sql/variables.tf
+++ b/terraform/modules/cloud-sql/variables.tf
@@ -17,3 +17,8 @@ variable "db_user" {
   description = "The username for the database."
   type        = string
 }
+
+variable "private_service_access_id" {
+  description = "The ID of the private service access connection."
+  type        = string
+}

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -7,3 +7,8 @@ output "vpc_connector_id" {
     description = "The ID of the VPC connector"
     value = google_vpc_access_connector.main.id
 }
+
+output "private_service_access_id" {
+  description = "The ID of the private service access connection."
+  value       = google_service_networking_connection.private_service_access.id
+}


### PR DESCRIPTION
This commit provides a comprehensive set of fixes for the remaining errors encountered during the `terraform apply` step.

The changes include:
1.  **Enabling necessary APIs:** The `secretmanager.googleapis.com` and `servicenetworking.googleapis.com` APIs are now enabled in `cloudbuild.yaml`.
2.  **Granting IAM permissions:** The Cloud Build service account is now granted the `roles/compute.networkAdmin` role to allow it to create VPC peerings.
3.  **Fixing Terraform dependency:** An explicit dependency has been added between the Cloud SQL instance and the VPC private service connection to prevent a race condition during creation. This was done by passing the ID of the service connection to the `cloud_sql` module and using it in a `depends_on` block.

These changes should resolve all the outstanding issues and allow the Terraform configuration to be applied successfully.